### PR TITLE
Release v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/signalfx/signalflow-client-go/compare/v0.1.0...main)
+## [Unreleased](https://github.com/signalfx/signalflow-client-go/compare/v2.3.0...main)
 
-## [v0.1.0](https://github.com/signalfx/signalflow-client-go/releases/tag/v0.1.0)
+## [v2.3.0](https://github.com/signalfx/signalflow-client-go/releases/tag/v2.3.0) - 2024-04-25
 
 This is the first release after the `github.com/signalfx/signalfx-go/signalflow/v2`
 migration to this repository. In order to migrate from the deprecated package
 you have to replace `github.com/signalfx/signalfx-go/signalflow/v2` with
-`github.com/signalfx/signalflow-client-go/signalflow`.
+`github.com/signalfx/signalflow-client-go/v2/signalflow`.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SignalFlow Go Client
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/signalfx/signalflow-client-go/signalflow.svg)](https://pkg.go.dev/github.com/signalfx/signalflow-client-go/signalflow)
+[![Go Reference](https://pkg.go.dev/badge/github.com/signalfx/signalflow-client-go/v2/signalflow.svg)](https://pkg.go.dev/github.com/signalfx/signalflow-client-go/v2/signalflow)
 [![go.mod](https://img.shields.io/github/go-mod/go-version/signalfx/signalflow-client-go)](go.mod)
 
 [![Keep a Changelog](https://img.shields.io/badge/changelog-Keep%20a%20Changelog-%23E05735)](CHANGELOG.md)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/signalfx/signalflow-client-go
+module github.com/signalfx/signalflow-client-go/v2
 
 go 1.21
 

--- a/signalflow/client.go
+++ b/signalflow/client.go
@@ -15,7 +15,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-	"github.com/signalfx/signalflow-client-go/signalflow/messages"
+	"github.com/signalfx/signalflow-client-go/v2/signalflow/messages"
 )
 
 // Client for SignalFlow via websockets (SSE is not currently supported).

--- a/signalflow/client_test.go
+++ b/signalflow/client_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/signalfx/signalflow-client-go/signalflow/messages"
+	"github.com/signalfx/signalflow-client-go/v2/signalflow/messages"
 	"github.com/signalfx/signalfx-go/idtool"
 	"github.com/stretchr/testify/require"
 )

--- a/signalflow/computation.go
+++ b/signalflow/computation.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/signalfx/signalflow-client-go/signalflow/messages"
+	"github.com/signalfx/signalflow-client-go/v2/signalflow/messages"
 	"github.com/signalfx/signalfx-go/idtool"
 )
 

--- a/signalflow/computation_test.go
+++ b/signalflow/computation_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/signalfx/signalflow-client-go/signalflow/messages"
+	"github.com/signalfx/signalflow-client-go/v2/signalflow/messages"
 	"github.com/signalfx/signalfx-go/idtool"
 	"github.com/stretchr/testify/require"
 )

--- a/signalflow/example_test.go
+++ b/signalflow/example_test.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/signalfx/signalflow-client-go/signalflow"
+	"github.com/signalfx/signalflow-client-go/v2/signalflow"
 )
 
 func Example() {

--- a/signalflow/fake_backend.go
+++ b/signalflow/fake_backend.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-	"github.com/signalfx/signalflow-client-go/signalflow/messages"
+	"github.com/signalfx/signalflow-client-go/v2/signalflow/messages"
 	"github.com/signalfx/signalfx-go/idtool"
 )
 

--- a/signalflow/fake_backend_test.go
+++ b/signalflow/fake_backend_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/signalfx/signalflow-client-go/signalflow/messages"
+	"github.com/signalfx/signalflow-client-go/v2/signalflow/messages"
 	"github.com/signalfx/signalfx-go/idtool"
 	"github.com/stretchr/testify/assert"
 )


### PR DESCRIPTION
This is the first release after the `github.com/signalfx/signalfx-go/signalflow/v2` migration to this repository. In order to migrate from the deprecated package you have to replace `github.com/signalfx/signalfx-go/signalflow/v2` with `github.com/signalfx/signalflow-client-go/v2/signalflow`.

### Added

- Add `SetLogger` method `FakeBackend` to allow setting an internal logger. ([#12](https://github.com/signalfx/signalflow-client-go/pull/12))

### Changed

- `FakeBackend` no longer emits internal logs using global `log`. ([#12](https://github.com/signalfx/signalflow-client-go/pull/12))

### Fixed

- Fix a goroutine leak and close the channel returned by `Computation.Events` when the computation finishes. ([#15](https://github.com/signalfx/signalflow-client-go/pull/15))